### PR TITLE
Add initial-site-settings

### DIFF
--- a/.cloudcannon/initial-site-settings.json
+++ b/.cloudcannon/initial-site-settings.json
@@ -1,0 +1,28 @@
+{
+  "ssg": "jekyll",
+  "build_configuration": {
+    "preserved_paths": "node_modules/",
+    "source": "site",
+    "config": "",
+    "limit_posts": "",
+    "incremental": false,
+    "drafts": false,
+    "unpublished": false,
+    "future": false,
+    "lsi": false,
+    "trace": false,
+    "verbose": false,
+    "quiet": false,
+    "profile": false,
+    "use_local_bundle": true,
+    "enable_bundle_cache": true,
+    "autosync_gemlock": false,
+    "includeGit": false,
+    "preserveOutput": false,
+    "environment_variables": [
+      { "key": "JEKYLL_ENV", "value": "production" },
+      { "key": "BUNDLE_GEMFILE", "value": "site/Gemfile" }
+    ],
+    "jekyll_environment": "production"
+  }
+}

--- a/.cloudcannon/initial-site-settings.json
+++ b/.cloudcannon/initial-site-settings.json
@@ -20,8 +20,7 @@
     "includeGit": false,
     "preserveOutput": false,
     "environment_variables": [
-      { "key": "JEKYLL_ENV", "value": "production" },
-      { "key": "BUNDLE_GEMFILE", "value": "site/Gemfile" }
+      { "key": "JEKYLL_ENV", "value": "production" }
     ],
     "jekyll_environment": "production"
   }


### PR DESCRIPTION
Add .cloudcannon/initial-build-settings.json file. This specifies all the details CloudCannon needs to build the site, so that templates can be loaded directly into CloudCannon and built without asking the using for configuration. In most cases, the default config for the SSG is correct, so this file may only need to specify the SSG it uses.